### PR TITLE
Fix deprecated ggiraph functions (ggiraphOutput/renderggiraph → girafeOutput/renderGirafe)

### DIFF
--- a/inst/shiny/microhaplot/server.R
+++ b/inst/shiny/microhaplot/server.R
@@ -2582,7 +2582,7 @@ while the bottom panel hosts a wide selection of tables and graphical summaries.
 
   },height=function(){ifelse(input$selectLocus == "ALL",1,150)})
 
-  output$biplot <-renderggiraph({
+  output$biplot <-renderGirafe({
     #output$biplot <-renderPlot({
 
     #renderPlot({

--- a/inst/shiny/microhaplot/ui.R
+++ b/inst/shiny/microhaplot/ui.R
@@ -510,7 +510,7 @@ shinyUI(
                                                    step = 0.01))
                      ),
                      column(8,
-                            ggiraph::ggiraphOutput("biplot", height = "450px"),
+                            ggiraph::girafeOutput("biplot", height = "450px"),
                             height="auto",
                             style= "width:'100%'"),
                      column(12,


### PR DESCRIPTION
## Summary
- `ggiraph::ggiraphOutput()` and `ggiraph::renderggiraph()` are defunct in recent versions of the ggiraph package, causing the app to fail on startup with "'ggiraphOutput' is defunct. Use 'girafeOutput' instead."
- Replaces them with the current equivalents, `ggiraph::girafeOutput()` and `ggiraph::renderGirafe()`, in `inst/shiny/microhaplot/ui.R` and `inst/shiny/microhaplot/server.R`.

## Test plan
- [x] Confirmed `girafeOutput`/`renderGirafe` exist and are the documented replacements in ggiraph 0.9.6 (`?ggiraph::Defunct`)
- [x] Ran `runShinyHaplot()` locally — app launches and the biplot tab renders without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)